### PR TITLE
Bugfix decrement manually billed org donation

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -36,10 +36,9 @@ class Mongo {
     })
 
     if (!org) return org
+    const { _id: id, name, host, installationId, remainingDonation, totalDonated, billingInfo } = org
 
-    const { name, host, installationId } = org
-
-    return { name, host, installationId }
+    return { id, name, host, installationId, remainingDonation, totalDonated, billingInfo }
   }
 
   async distributeOrgDonation ({ donationAmount, packageWeightsMap, language, registry, organizationId, description }) {

--- a/lib/process.js
+++ b/lib/process.js
@@ -70,9 +70,8 @@ exports.process = async ({ log, record, db, resolver, s3 }) => {
 
   // If the org is manually billed, we need to decriment the amount we just distributed from the orgs remaining amount
   const isManuallyBilledOrganization = !!(org && org.billingInfo && org.billingInfo.manuallyBilled)
-  log.info({ isManuallyBilledOrganization, org })
   if (isManuallyBilledOrganization) {
-    log.info('decrimenting org remaining amount')
+    log.info("manually-billed org; decrimenting org's remaining donation amount")
     await db.decrementManuallyBilledOrgRemainingDonation({ organizationId, amount })
   }
 

--- a/test/mongo.test.js
+++ b/test/mongo.test.js
@@ -93,7 +93,7 @@ test('increment org total amount donated from existing value', async (t) => {
 
   await mongo.updateDonatedAmount({ organizationId: orgId1.toString(), amount: 1000 })
 
-  const updatedOrg = await mongo.db.collection('organizations').findOne({ _id: orgId1 })
+  const updatedOrg = await mongo.getOrg({ organizationId: orgId1.toString() })
   t.deepEqual(updatedOrg.totalDonated, 2000)
 })
 
@@ -111,7 +111,7 @@ test('decrement manually billed org remaining donation', async (t) => {
 
   await mongo.decrementManuallyBilledOrgRemainingDonation({ organizationId: orgId1.toString(), amount: 1000 })
 
-  const updatedOrg = await mongo.db.collection('organizations').findOne({ _id: orgId1 })
+  const updatedOrg = await mongo.getOrg({ organizationId: orgId1.toString() })
   t.deepEqual(updatedOrg.remainingDonation, 0)
 })
 


### PR DESCRIPTION
Issue was that `getOrg` was not returning the `billingInfo` structure. Updated to return all the parts needed for running and tests (not the whole org so that we don't pull in a potentially large `snapshots` array).